### PR TITLE
Add RingCentral SMS compliance language

### DIFF
--- a/src/components/EnhancedContactForm.astro
+++ b/src/components/EnhancedContactForm.astro
@@ -363,7 +363,7 @@ const config = getFormConfig(formType);
           <label class="checkbox-item consent-checkbox">
             <input type="checkbox" name="consent" required />
             <span class="checkmark"></span>
-            I agree to receive communications from KPS Group and understand my information will be used according to the <a href="/privacy" target="_blank">Privacy Policy</a>
+            I consent to receive Conversations (external) text messages from The KPS Group LLC. Reply STOP to opt-out; Reply HELP for support; Message and data rates apply; Messaging frequency may vary. Visit our <a href="/privacy-policy" target="_blank">Privacy Policy</a> and <a href="/terms-of-service" target="_blank">Terms of Service</a>.
           </label>
           <div class="field-error" data-error="consent"></div>
         </div>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -114,7 +114,7 @@ const seoProps = {
               <ul class="space-y-2 text-gray-300">
                 <li class="flex items-start gap-2">
                   <div class="w-1.5 h-1.5 bg-gold rounded-full mt-2 flex-shrink-0"></div>
-                  <span>Name, Email, and Phone Number when you submit a contact form</span>
+                  <span>Name, email, and phone number when you submit a contact form (phone numbers may be used for SMS communications with your consent)</span>
                 </li>
                 <li class="flex items-start gap-2">
                   <div class="w-1.5 h-1.5 bg-gold rounded-full mt-2 flex-shrink-0"></div>
@@ -150,6 +150,27 @@ const seoProps = {
               </ul>
             </div>
 
+            <div class="bg-gray-800/50 rounded-xl p-6 border border-gray-700/50">
+              <h3 class="text-lg font-semibold text-goldLight mb-4 flex items-center gap-2">
+                <svg class="w-5 h-5 text-gold" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h6m-6 8l-4-4V5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H7z"/>
+                </svg>
+                SMS Text Messaging
+              </h3>
+              <p class="text-gray-300 mb-4">
+                We use RingCentral to send service-related text messages to users who opt in via our
+                <a href="https://www.thekpsgroup.com/contact" class="underline">contact form</a>. This form states:
+                "I consent to receive Conversations (external) text messages from The KPS Group LLC. Reply STOP to opt-out; Reply
+                HELP for support; Message and data rates apply; Messaging frequency may vary. Visit
+                https://www.thekpsgroup.com/privacy-policy for privacy policy and
+                https://www.thekpsgroup.com/terms-of-service for Terms of Service."
+              </p>
+              <p class="text-gray-300">
+                Message frequency varies and you may opt out at any time by replying STOP. Your phone number is used solely for
+                these communications and is handled in accordance with this privacy policy.
+              </p>
+            </div>
+
             <div class="bg-gradient-to-r from-gold/10 to-goldLight/10 rounded-xl p-6 border border-gold/30">
               <h3 class="text-lg font-semibold text-gold mb-3 flex items-center gap-2">
                 <svg class="w-5 h-5 text-gold" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -174,7 +195,7 @@ const seoProps = {
 
           <div class="mt-8 pt-6 border-t border-gray-700/50 text-center">
             <p class="text-sm text-gray-400">
-              Last updated: July 2025
+              Last updated: August 13, 2025
             </p>
           </div>
         </div>

--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -105,49 +105,59 @@ const seoProps = {
           </div>
 
           <div>
-            <h2 class="text-2xl font-bold text-warning-400 mb-4">4. Revisions and Changes</h2>
+            <h2 class="text-2xl font-bold text-warning-400 mb-4">4. SMS/Text Messaging Terms</h2>
+            <p class="text-gray-300 leading-relaxed mb-4">
+              By providing your phone number and opting in through our <a href="https://www.thekpsgroup.com/contact" class="underline">contact form</a>, you consent to receive Conversations (external) text messages from The KPS Group LLC via RingCentral. Message and data rates may apply, and messaging frequency may vary. Reply STOP to opt out or HELP for assistance. Consent is not a condition of purchase.
+            </p>
+            <p class="text-gray-300 leading-relaxed">
+              We use your phone number solely for these communications and handle it according to our <a href="/privacy-policy" class="underline">Privacy Policy</a>.
+            </p>
+          </div>
+
+          <div>
+            <h2 class="text-2xl font-bold text-warning-400 mb-4">5. Revisions and Changes</h2>
             <p class="text-gray-300 leading-relaxed">
               Each project includes a specified number of revisions as outlined in your service package. Additional revisions beyond the included amount may incur additional charges.
             </p>
           </div>
 
           <div>
-            <h2 class="text-2xl font-bold text-warning-400 mb-4">5. Intellectual Property</h2>
+            <h2 class="text-2xl font-bold text-warning-400 mb-4">6. Intellectual Property</h2>
             <p class="text-gray-300 leading-relaxed">
               Upon completion of engagement, you will own the deliverables and outcomes specified in your agreement. The KPS Group retains the right to reference completed work in our portfolio unless otherwise specified.
             </p>
           </div>
 
           <div>
-            <h2 class="text-2xl font-bold text-warning-400 mb-4">6. Timeline and Delivery</h2>
+            <h2 class="text-2xl font-bold text-warning-400 mb-4">7. Timeline and Delivery</h2>
             <p class="text-gray-300 leading-relaxed">
               Project timelines are estimates and may vary based on client responsiveness and project complexity. Rush delivery options are available for an additional fee.
             </p>
           </div>
 
           <div>
-            <h2 class="text-2xl font-bold text-warning-400 mb-4">7. Satisfaction Guarantee</h2>
+            <h2 class="text-2xl font-bold text-warning-400 mb-4">8. Satisfaction Guarantee</h2>
             <p class="text-gray-300 leading-relaxed">
               We offer a 100% satisfaction guarantee. If you're not completely satisfied with your final deliverables, we will work with you to make it right or provide a full refund.
             </p>
           </div>
 
           <div>
-            <h2 class="text-2xl font-bold text-warning-400 mb-4">8. Limitation of Liability</h2>
+            <h2 class="text-2xl font-bold text-warning-400 mb-4">9. Limitation of Liability</h2>
             <p class="text-gray-300 leading-relaxed">
               The KPS Group's liability is limited to the amount paid for services. We are not liable for any indirect, incidental, or consequential damages.
             </p>
           </div>
 
           <div>
-            <h2 class="text-2xl font-bold text-warning-400 mb-4">9. Governing Law</h2>
+            <h2 class="text-2xl font-bold text-warning-400 mb-4">10. Governing Law</h2>
             <p class="text-gray-300 leading-relaxed">
               These terms are governed by the laws of the State of Texas. Any disputes will be resolved in the courts of Texas.
             </p>
           </div>
 
           <div>
-            <h2 class="text-2xl font-bold text-warning-400 mb-4">10. Contact Information</h2>
+            <h2 class="text-2xl font-bold text-warning-400 mb-4">11. Contact Information</h2>
             <p class="text-gray-300 leading-relaxed">
               If you have any questions about these Terms of Service, please contact us at:
             </p>
@@ -161,7 +171,7 @@ const seoProps = {
 
           <div class="text-center pt-8 border-t border-accent-700/30">
             <p class="text-gray-400 text-sm">
-              Last updated: July 23, 2025
+              Last updated: August 13, 2025
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Update contact form opt-in text with STOP/HELP, data rates and policy links for SMS compliance
- Add SMS messaging section to privacy policy describing opt-in, opt-out, and RingCentral usage
- Introduce SMS/text messaging terms in terms of service and refresh revision dates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cea6ec698832a84347c764713e092