### PR TITLE
HQ baseline: black/gold theme, nav/CTAs, contact enforcement, nationwide SEO, analytics, tests aligned

### DIFF
--- a/src/components/LeadForm.tsx
+++ b/src/components/LeadForm.tsx
@@ -1,5 +1,7 @@
-import React, { useState, useEffect, FormEvent } from 'react';
-import { leadSchema, submitLead, LeadInput } from '../lib/lead';
+import React, { useState, useEffect } from 'react';
+import type { FormEvent } from 'react';
+import { leadSchema, submitLead } from '../lib/lead';
+import type { LeadInput } from '../lib/lead';
 
 interface Props {
   formId?: string;

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -4,8 +4,10 @@ test("core routes load and CTA present", async ({ page }) => {
   for (const path of ["/", "/about", "/services", "/contact"]) {
     await page.goto(path);
     await expect(page.locator("body")).toBeVisible();
-    await expect(page.getByText("469-458-6966")).toBeVisible();
-    await expect(page.locator('a[href="tel:+14694586966"]')).toHaveCount(1);
+    const phoneText = page.locator('text=469-458-6966').first();
+    await expect(phoneText).toBeVisible();
+    const phoneLink = page.locator('a[href="tel:+14694586966"]').first();
+    await expect(phoneLink).toBeVisible();
   }
 
   // CTA sections render


### PR DESCRIPTION
## Summary
- use type-only imports in lead form to resolve build warnings
- update smoke test to handle multiple contact links and texts

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cfc88968c832a94f2bb006c0bd809